### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Gobble.php
+++ b/src/Gobble.php
@@ -30,6 +30,6 @@ class Gobble extends Plugin
         // Create a new Guzzle client
         $client = new Client();
 
-        Craft::$app->view->twig->addExtension(new GobbleTwigExtensions($client));
+        Craft::$app->view->registerTwigExtension(new GobbleTwigExtensions($client));
     }
 }


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.